### PR TITLE
Increase test coverage

### DIFF
--- a/KeyDerivationInterface/Keys/Keys.cs
+++ b/KeyDerivationInterface/Keys/Keys.cs
@@ -18,6 +18,7 @@ using KeyDerivation.Entities;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Math.EC;
 using Org.BouncyCastle.Math.EC.Multiplier;
 using Org.BouncyCastle.Security;
@@ -107,7 +108,7 @@ namespace KeyDerivation.Keys
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return new BigInteger(scalar.Concat(ChainCode).ToArray()).GetHashCode();
         }
     }
 
@@ -207,7 +208,7 @@ namespace KeyDerivation.Keys
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return publicKey.GetHashCode() + new BigInteger(ChainCode).GetHashCode();
         }
     }
 }

--- a/KeyDerivationLibTests/DerivationKeyFactoryTests.cs
+++ b/KeyDerivationLibTests/DerivationKeyFactoryTests.cs
@@ -96,5 +96,11 @@ namespace KeyDerivationLibTests
 
             Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different KeyIndex have to be different too");
         }
+
+        [Test]
+        public void NullDerivationKeyParamThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => DerivationKeyFactory.DerivePrivateChildKey(null, 1));
+        }
     }
 }

--- a/KeyDerivationLibTests/KeysTests.cs
+++ b/KeyDerivationLibTests/KeysTests.cs
@@ -1,0 +1,57 @@
+﻿using KeyDerivationLib;
+
+namespace KeyDerivationLibTests
+{
+    public class KeysTests
+    {
+        [Test]
+        public void PrivateDerivationKeyEqualsCorrectWork()
+        {
+            var key1 = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var key2 = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var key3 = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.WrongTag);
+            
+            Assert.That(key1.Equals(key1), Is.EqualTo(true));
+            Assert.That(key1.Equals(key2), Is.EqualTo(true));
+            Assert.That(key1.Equals(key3), Is.EqualTo(false));
+            Assert.That(key1!=key2, Is.EqualTo(false));
+            Assert.That(key1!=key3, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void PublicDerivationKeyEqualsCorrectWork()
+        {
+            var key1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var key3 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, NewTestData.WrongTag);
+
+            Assert.That(key1.Equals(key1), Is.EqualTo(true));
+            Assert.That(key1.Equals(key2), Is.EqualTo(true));
+            Assert.That(key1.Equals(key3), Is.EqualTo(false));
+        }
+
+        [Test]
+        public void PrivateDerivationKeyGethashCodeCorrectWork()
+        {
+            var key = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, "");
+            var key2 = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, "");
+            var key3 = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, "text");
+
+            Assert.That(key.GetHashCode(), Is.EqualTo(NewTestData.PrivateKeyHashCode));
+            Assert.That(key.GetHashCode(), Is.EqualTo(key2.GetHashCode()));
+            Assert.That(key.GetHashCode(), Is.Not.EqualTo(key3.GetHashCode()));
+        }
+
+        [Test]
+        public void PublicDerivationKeyGethashCodeCorrectWork()
+        {
+            var key = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, "");
+            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, "");
+            var key3 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey, "text");
+
+            Assert.That(key.GetHashCode(), Is.EqualTo(NewTestData.PublicKeyHashCode));
+            Assert.That(key.GetHashCode(), Is.EqualTo(key2.GetHashCode()));
+            Assert.That(key.GetHashCode(), Is.Not.EqualTo(key3.GetHashCode()));
+        }
+    }
+}

--- a/KeyDerivationLibTests/KeysTests.cs
+++ b/KeyDerivationLibTests/KeysTests.cs
@@ -1,4 +1,20 @@
-﻿using KeyDerivationLib;
+﻿///////////////////////////////////////////////////////////////////////////////
+//   Copyright 2023 Eppie (https://eppie.io)
+//
+//   Licensed under the Apache License, Version 2.0(the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+///////////////////////////////////////////////////////////////////////////////
+
+using KeyDerivationLib;
 
 namespace KeyDerivationLibTests
 {

--- a/KeyDerivationLibTests/NewTestData.cs
+++ b/KeyDerivationLibTests/NewTestData.cs
@@ -33,26 +33,26 @@ namespace KeyDerivationLibTests
             "abandon", "abandon", "abandon", "ability"
         };
 
-        public static string[] GetTestSeed()
-        {
-            return new string[] {
-                "ozone",    "drill",    "grab",
-                "fiber",    "curtain",  "grace",
-                "pudding",  "thank",    "cruise",
-                "elder",    "eight",    "picnic"
-            };
-        }
+        //public static string[] GetTestSeed()
+        //{
+        //    return new string[] {
+        //        "ozone",    "drill",    "grab",
+        //        "fiber",    "curtain",  "grace",
+        //        "pudding",  "thank",    "cruise",
+        //        "elder",    "eight",    "picnic"
+        //    };
+        //}
 
-        public static List<KeyValuePair<string, bool>> GetDictionaryTestData()
-        {
-            return new List<KeyValuePair<string, bool>>()
-            {
-                new KeyValuePair<string, bool>("hello", true),
-                new KeyValuePair<string, bool>("shine", true),
-                new KeyValuePair<string, bool>("abracadabra", false),
-                new KeyValuePair<string, bool>("fakdfbmsp", false)
-            };
-        }
+        //public static List<KeyValuePair<string, bool>> GetDictionaryTestData()
+        //{
+        //    return new List<KeyValuePair<string, bool>>()
+        //    {
+        //        new KeyValuePair<string, bool>("hello", true),
+        //        new KeyValuePair<string, bool>("shine", true),
+        //        new KeyValuePair<string, bool>("abracadabra", false),
+        //        new KeyValuePair<string, bool>("fakdfbmsp", false)
+        //    };
+        //}
 
         public static readonly MasterKey MasterKey = CreateMasterKey(TestSeedPhrase);
 
@@ -129,5 +129,9 @@ namespace KeyDerivationLibTests
                 0xad, 0x0e, 0xd5, 0xd7, 0xbc, 0x2f, 0x8c, 0xb6, 0xf5, 0x89, 0x9d, 0x8e, 0x27, 0xaf, 0x81, 0xfd
             }
         );
+
+        public const int PrivateKeyHashCode = -110109786;
+
+        public const int PublicKeyHashCode = 2111922444;
     }
 }

--- a/KeyDerivationLibTests/NewTestData.cs
+++ b/KeyDerivationLibTests/NewTestData.cs
@@ -33,27 +33,6 @@ namespace KeyDerivationLibTests
             "abandon", "abandon", "abandon", "ability"
         };
 
-        //public static string[] GetTestSeed()
-        //{
-        //    return new string[] {
-        //        "ozone",    "drill",    "grab",
-        //        "fiber",    "curtain",  "grace",
-        //        "pudding",  "thank",    "cruise",
-        //        "elder",    "eight",    "picnic"
-        //    };
-        //}
-
-        //public static List<KeyValuePair<string, bool>> GetDictionaryTestData()
-        //{
-        //    return new List<KeyValuePair<string, bool>>()
-        //    {
-        //        new KeyValuePair<string, bool>("hello", true),
-        //        new KeyValuePair<string, bool>("shine", true),
-        //        new KeyValuePair<string, bool>("abracadabra", false),
-        //        new KeyValuePair<string, bool>("fakdfbmsp", false)
-        //    };
-        //}
-
         public static readonly MasterKey MasterKey = CreateMasterKey(TestSeedPhrase);
 
         public static readonly MasterKey MasterKey2 = CreateMasterKey(TestSeedPhrase2);

--- a/KeyDerivationLibTests/PrivateDerivationFactoryTests.cs
+++ b/KeyDerivationLibTests/PrivateDerivationFactoryTests.cs
@@ -25,7 +25,7 @@ using Org.BouncyCastle.Math.EC;
 
 namespace KeyDerivationLibTests
 {
-    public class NewDerivationKeyFactoryTests
+    public class PrivateDerivationKeyFactoryTests
     {
         [Test]
         public void CompareDerivatedKeys()
@@ -116,80 +116,15 @@ namespace KeyDerivationLibTests
         }
 
         [Test]
-        public void PublicDerivationKeysAreDeterministic()
+        public void CreatePrivateDerivationKeyNullKeyParamThrowsArgumentNullException()
         {
-            var initialPrivateKey = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
-            var initialPublicKey = initialPrivateKey.PublicDerivationKey;
-            var resultPublicKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(initialPublicKey, NewTestData.RightTag);
-
-            Assert.That(NewTestData.InitailPublicKey.compressedKey, Is.EqualTo(initialPublicKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
-            Assert.That(NewTestData.InitailPublicKey.chainCode, Is.EqualTo(initialPublicKey.ChainCode), "Key is not same as predicted");
-            Assert.That(NewTestData.ResultPublicKey.compressedKey, Is.EqualTo(resultPublicKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
-            Assert.That(NewTestData.ResultPublicKey.chainCode, Is.EqualTo(resultPublicKey.ChainCode), "Key is not same as predicted");
+            Assert.Throws<ArgumentNullException>(() => PrivateDerivationKeyFactory.CreatePrivateDerivationKey(null, "some text"));            
         }
 
         [Test]
-        public void PublicDerivationKeysAreDifferentWithMasterKey()
+        public void DerivePrivateChildKeyNullKeyParamThrowsArgumentNullException()
         {
-            var key1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
-            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey2.PublicDerivationKey, NewTestData.RightTag);
-
-            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different MasterKey have to be different too");
-        }
-
-        [Test]
-        public void PublicDerivationKeysAreDifferentWithTags()
-        {
-            var key1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
-            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.WrongTag);
-
-            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different userId have to be different too");
-        }
-
-        [Test]
-        public void PublicChildKeysAreDifferentWithMasterKey()
-        {
-            var derivationKey1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
-            var derivationKey2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey2.PublicDerivationKey, NewTestData.RightTag);
-
-            var key1 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey1, 0);
-            var key2 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey2, 0);
-
-            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different MasterKey have to be different too");
-        }
-
-        [Test]
-        public void PublicChildKeysAreDifferentWithKeyIndex()
-        {
-            var derivationKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
-
-            var key1 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey, 0);
-            var key2 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey, 1);
-
-            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different KeyIndex have to be different too");
-        }
-
-        [Test]
-        public void CompareChildDerivatedKeys()
-        {
-            var privateDerivationKey = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);            
-            var childPrivateKey = PrivateDerivationKeyFactory.DerivePrivateChildKey(privateDerivationKey, 0);
-            
-            string BitcoinEllipticCurveName = "secp256k1";
-            DerObjectIdentifier curveOid = ECNamedCurveTable.GetOid(BitcoinEllipticCurveName);
-            ECKeyGenerationParameters keyParams = new ECKeyGenerationParameters(curveOid, new SecureRandom());
-            ECPrivateKeyParameters privateKey = new ECPrivateKeyParameters("EC", new BigInteger(1, childPrivateKey), keyParams.PublicKeyParamSet);
-            ECMultiplier multiplier = new FixedPointCombMultiplier();
-            ECPoint q = multiplier.Multiply(keyParams.DomainParameters.G, privateKey.D); // child public key from private key
-
-            var publicDerivationKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
-            var childPublicKey = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(publicDerivationKey, 0);
-            ECPoint q2 = keyParams.DomainParameters.Curve.DecodePoint(childPublicKey); // child public key from public key
-
-            ECPoint q3 = PublicDerivationKeyFactory.DerivePublicChildKeyAsECPoint(publicDerivationKey, 0);
-
-            Assert.That(q, Is.EqualTo(q2));
-            Assert.That(q, Is.EqualTo(q3));
+            Assert.Throws<ArgumentNullException>(() => PrivateDerivationKeyFactory.DerivePrivateChildKey(null, 1));
         }
     }
 }

--- a/KeyDerivationLibTests/PrivateDerivationFactoryTests.cs
+++ b/KeyDerivationLibTests/PrivateDerivationFactoryTests.cs
@@ -15,13 +15,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 using KeyDerivationLib;
-using Org.BouncyCastle.Asn1.X9;
-using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Math.EC.Multiplier;
-using Org.BouncyCastle.Security;
-using Org.BouncyCastle.Math;
-using Org.BouncyCastle.Math.EC;
 
 namespace KeyDerivationLibTests
 {

--- a/KeyDerivationLibTests/PublicDerivationKeyFactoryTests.cs
+++ b/KeyDerivationLibTests/PublicDerivationKeyFactoryTests.cs
@@ -1,0 +1,117 @@
+﻿using KeyDerivationLib;
+using Org.BouncyCastle.Asn1.X9;
+using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Math.EC.Multiplier;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.Math.EC;
+using Org.BouncyCastle.Math;
+using KeyDerivation.Keys;
+
+namespace KeyDerivationLibTests
+{
+    public class PublicDerivationKeyFactoryTests
+    {
+        [Test]
+        public void PublicDerivationKeysAreDeterministic()
+        {
+            var initialPrivateKey = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var initialPublicKey = initialPrivateKey.PublicDerivationKey;
+            var resultPublicKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(initialPublicKey, NewTestData.RightTag);
+
+            Assert.That(NewTestData.InitailPublicKey.compressedKey, Is.EqualTo(initialPublicKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
+            Assert.That(NewTestData.InitailPublicKey.chainCode, Is.EqualTo(initialPublicKey.ChainCode), "Key is not same as predicted");
+            Assert.That(NewTestData.ResultPublicKey.compressedKey, Is.EqualTo(resultPublicKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
+            Assert.That(NewTestData.ResultPublicKey.chainCode, Is.EqualTo(resultPublicKey.ChainCode), "Key is not same as predicted");
+        }
+
+        [Test]
+        public void PublicDerivationKeysAreDeterministicFromPrivateKey()
+        {
+            var initialPrivateKey = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var resultPublicKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(initialPrivateKey, NewTestData.RightTag);
+
+            Assert.That(NewTestData.InitailPublicKey.compressedKey, Is.EqualTo(initialPrivateKey.PublicDerivationKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
+            Assert.That(NewTestData.InitailPublicKey.chainCode, Is.EqualTo(initialPrivateKey.PublicDerivationKey.ChainCode), "Key is not same as predicted");
+            Assert.That(NewTestData.ResultPublicKey.compressedKey, Is.EqualTo(resultPublicKey.PublicKey.GetEncoded(true)), "Key is not same as predicted");
+            Assert.That(NewTestData.ResultPublicKey.chainCode, Is.EqualTo(resultPublicKey.ChainCode), "Key is not same as predicted");
+        }
+
+        [Test]
+        public void PublicDerivationKeysAreDifferentWithMasterKey()
+        {
+            var key1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
+            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey2.PublicDerivationKey, NewTestData.RightTag);
+
+            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different MasterKey have to be different too");
+        }
+
+        [Test]
+        public void PublicDerivationKeysAreDifferentWithTags()
+        {
+            var key1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
+            var key2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.WrongTag);
+
+            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different userId have to be different too");
+        }
+
+        [Test]
+        public void PublicChildKeysAreDifferentWithMasterKey()
+        {
+            var derivationKey1 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
+            var derivationKey2 = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey2.PublicDerivationKey, NewTestData.RightTag);
+
+            var key1 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey1, 0);
+            var key2 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey2, 0);
+
+            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different MasterKey have to be different too");
+        }
+
+        [Test]
+        public void PublicChildKeysAreDifferentWithKeyIndex()
+        {
+            var derivationKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
+
+            var key1 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey, 0);
+            var key2 = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(derivationKey, 1);
+
+            Assert.That(key2, Is.Not.EqualTo(key1), "Keys with different KeyIndex have to be different too");
+        }
+
+        [Test]
+        public void CompareChildDerivatedKeys()
+        {
+            var privateDerivationKey = PrivateDerivationKeyFactory.CreatePrivateDerivationKey(NewTestData.MasterKey, NewTestData.RightTag);
+            var childPrivateKey = PrivateDerivationKeyFactory.DerivePrivateChildKey(privateDerivationKey, 0);
+
+            string BitcoinEllipticCurveName = "secp256k1";
+            DerObjectIdentifier curveOid = ECNamedCurveTable.GetOid(BitcoinEllipticCurveName);
+            ECKeyGenerationParameters keyParams = new ECKeyGenerationParameters(curveOid, new SecureRandom());
+            ECPrivateKeyParameters privateKey = new ECPrivateKeyParameters("EC", new BigInteger(1, childPrivateKey), keyParams.PublicKeyParamSet);
+            ECMultiplier multiplier = new FixedPointCombMultiplier();
+            ECPoint q = multiplier.Multiply(keyParams.DomainParameters.G, privateKey.D); // child public key from private key
+
+            var publicDerivationKey = PublicDerivationKeyFactory.CreatePublicDerivationKey(NewTestData.MasterKey.PublicDerivationKey, NewTestData.RightTag);
+            var childPublicKey = PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(publicDerivationKey, 0);
+            ECPoint q2 = keyParams.DomainParameters.Curve.DecodePoint(childPublicKey); // child public key from public key
+
+            ECPoint q3 = PublicDerivationKeyFactory.DerivePublicChildKeyAsECPoint(publicDerivationKey, 0);
+
+            Assert.That(q, Is.EqualTo(q2));
+            Assert.That(q, Is.EqualTo(q3));
+        }
+
+        [Test]
+        public void DerivePublicChildKeyAsBytesNullKeyParamThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => PublicDerivationKeyFactory.DerivePublicChildKeyAsBytes(null, 1));
+        }
+
+        [Test]
+        public void CreatePublicChildKeyAsBytesNullKeyParamThrowsArgumentNullException()
+        {
+            PrivateDerivationKey? derivationKey = null;
+            Assert.Throws<ArgumentNullException>(() => PublicDerivationKeyFactory.CreatePublicDerivationKey(derivationKey, ""));
+        }
+    }
+}

--- a/KeyDerivationLibTests/PublicDerivationKeyFactoryTests.cs
+++ b/KeyDerivationLibTests/PublicDerivationKeyFactoryTests.cs
@@ -1,4 +1,20 @@
-﻿using KeyDerivationLib;
+﻿///////////////////////////////////////////////////////////////////////////////
+//   Copyright 2023 Eppie (https://eppie.io)
+//
+//   Licensed under the Apache License, Version 2.0(the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+///////////////////////////////////////////////////////////////////////////////
+
+using KeyDerivationLib;
 using Org.BouncyCastle.Asn1.X9;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Crypto.Parameters;


### PR DESCRIPTION
Increase test coverage. 
Change keys GetHashCode() methods. Because it didn't work properly.